### PR TITLE
Replace navigation buttons with administrator email link

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -362,8 +362,7 @@ function generateBlockingPage(ruleName, ruleId, blockedUrl, category, timestamp)
             </div>
             
             <div class="actions">
-                <a href="javascript:history.back()" class="btn btn-secondary">Go Back</a>
-                <a href="/" class="btn">Go to Homepage</a>
+                <a href="mailto:support@macharpe.com?subject=Access%20Blocked%20-%20Please%20Review&body=Hello,%0A%0AI%20was%20blocked%20from%20accessing:%0A${blockedUrl ? encodeURIComponent(displayUrl) : 'N/A'}%0A%0ARule:%20${encodeURIComponent(ruleName)}%0ARule%20ID:%20${ruleId || 'N/A'}%0A${category ? `Category:%20${encodeURIComponent(category)}%0A` : ''}%0ATime:%20${encodeURIComponent(timestamp ? new Date(timestamp).toLocaleString() : new Date().toLocaleString())}%0A%0APlease%20review%20this%20block%20as%20I%20believe%20it%20may%20be%20in%20error.%0A%0AThank%20you." class="btn">Contact Administrator</a>
             </div>
         </div>
         


### PR DESCRIPTION
## Summary
- Replace 'Go Back' and 'Go to Homepage' buttons with single 'Contact Administrator' button
- Email link pre-fills with blocked URL, rule details, category, and timestamp
- Provides users direct way to contact support@macharpe.com for potential false positives

## Changes
- Modified blocking page template to show administrator contact link
- Email includes all relevant blocking information for easier troubleshooting
- Maintains consistent styling with existing button design

## Test plan
- [ ] Deploy to test environment
- [ ] Verify email link opens with pre-filled content
- [ ] Test on different browsers and devices
- [ ] Confirm all blocking parameters are properly encoded in email body

🤖 Generated with [Claude Code](https://claude.ai/code)