### PR TITLE
Add Gateway context validation to prevent direct access

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -23,6 +23,22 @@ async function handleRequest(request, env) {
     const timestamp = url.searchParams.get('timestamp')
     const userEmail = url.searchParams.get('cf_user_email')
     
+    // Validate Gateway context - require at least one Gateway parameter
+    const hasGatewayContext = ruleId || blockedUrl || category || userEmail ||
+      url.searchParams.has('cf_rule_id') || url.searchParams.has('cf_site_uri') ||
+      url.searchParams.has('cf_request_category_names') || url.searchParams.has('cf_user_email')
+    
+    if (!hasGatewayContext) {
+      return new Response('Access Denied', {
+        status: 403,
+        headers: {
+          'Content-Type': 'text/plain',
+          'X-Frame-Options': 'DENY',
+          'X-Content-Type-Options': 'nosniff'
+        }
+      })
+    }
+    
     // Check for JSON API request
     const acceptHeader = request.headers.get('Accept')
     const isJsonRequest = acceptHeader && acceptHeader.includes('application/json')


### PR DESCRIPTION
## Summary
- Add validation to require Cloudflare Gateway parameters for access
- Return 403 Access Denied for direct domain access without Gateway context
- Prevents unauthorized access to block.macharpe.com domain

## Changes
- Check for presence of Gateway parameters (cf_rule_id, cf_site_uri, cf_request_category_names, cf_user_email)
- Return 403 status with "Access Denied" message for direct access attempts
- Maintain security headers in error response
- Ensures worker only functions when users are redirected from Gateway rules

## Security Benefits
- ✅ `block.macharpe.com?cf_rule_id=123&cf_site_uri=example.com` → Shows blocking page
- ❌ `block.macharpe.com` → Returns "Access Denied" (403)
- ❌ Direct browser access without parameters → Blocked

## Test plan
- [ ] Test direct domain access returns 403
- [ ] Test Gateway redirect with parameters works correctly
- [ ] Verify all Gateway parameter variations are detected
- [ ] Confirm JSON API requests also require Gateway context

🤖 Generated with [Claude Code](https://claude.ai/code)