### PR TITLE
docs: bust GitHub image cache for updated demo screenshot

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ A Cloudflare Worker that replaces the default Cloudflare Gateway block page with
 
 ## Demo
 
-![Blocking Page Demo](images/blocking-page-demo.png)
+![Blocking Page Demo](images/blocking-page-demo.png?v=2)
 
 ## Architecture
 


### PR DESCRIPTION
Appends `?v=2` to the demo image URL to force GitHub's CDN to serve the updated screenshot.